### PR TITLE
Refactor callback configuration

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -193,9 +193,9 @@ NAPI_METHOD(udx_napi_init) {
   int err = udx_init(udx, loop);
   if (err < 0) UDX_NAPI_THROW(err)
 
-  udx_set_callback(udx, UDX_ON_SEND, on_udx_send);
-  udx_set_callback(udx, UDX_ON_MESSAGE, on_udx_message);
-  udx_set_callback(udx, UDX_ON_CLOSE, on_udx_close);
+  udx_set_on_send(udx, on_udx_send);
+  udx_set_on_message(udx, on_udx_message);
+  udx_set_on_close(udx, on_udx_close);
 
   return NULL;
 }
@@ -322,11 +322,11 @@ NAPI_METHOD(udx_napi_stream_init) {
   int err = udx_stream_init(self, u, &local_id);
   if (err < 0) UDX_NAPI_THROW(err)
 
-  udx_stream_set_callback(u, UDX_STREAM_ON_DATA, on_udx_stream_data);
-  udx_stream_set_callback(u, UDX_STREAM_ON_END, on_udx_stream_end);
-  udx_stream_set_callback(u, UDX_STREAM_ON_DRAIN, on_udx_stream_drain);
-  udx_stream_set_callback(u, UDX_STREAM_ON_ACK, on_udx_stream_ack);
-  udx_stream_set_callback(u, UDX_STREAM_ON_CLOSE, on_udx_stream_close);
+  udx_stream_set_on_data(u, on_udx_stream_data);
+  udx_stream_set_on_end(u, on_udx_stream_end);
+  udx_stream_set_on_drain(u, on_udx_stream_drain);
+  udx_stream_set_on_ack(u, on_udx_stream_ack);
+  udx_stream_set_on_close(u, on_udx_stream_close);
 
   NAPI_RETURN_UINT32(local_id)
 }

--- a/src/udx.c
+++ b/src/udx.c
@@ -441,8 +441,8 @@ process_packet (udx_t *self, char *buf, ssize_t buf_len) {
 
     stream->ack++;
 
-    if (pkt->buf.iov_len > 0 && stream->on_read != NULL) {
-      stream->on_read(stream, pkt->buf.iov_base, pkt->buf.iov_len);
+    if (pkt->buf.iov_len > 0 && stream->on_data != NULL) {
+      stream->on_data(stream, pkt->buf.iov_base, pkt->buf.iov_len);
     }
 
     free(pkt);
@@ -620,25 +620,19 @@ udx_init (udx_t *self, uv_loop_t *loop) {
   return 0;
 }
 
-int
-udx_set_callback (udx_t *self, enum UDX_CALLBACK name, void *fn) {
-  switch (name) {
-    case UDX_ON_SEND: {
-      self->on_send = fn;
-      return 0;
-    }
-    case UDX_ON_MESSAGE: {
-      self->on_message = fn;
-      return 0;
-    }
-    case UDX_ON_CLOSE: {
-      self->on_close = fn;
-      return 0;
-    }
-    default: {
-      return -1;
-    }
-  }
+void
+udx_set_on_send(udx_t *self, udx_send_cb cb) {
+  self->on_send = cb;
+}
+
+void
+udx_set_on_message(udx_t *self, udx_message_cb cb) {
+  self->on_message = cb;
+}
+
+void
+udx_set_on_close(udx_t *self, udx_close_cb cb) {
+  self->on_close = cb;
 }
 
 int
@@ -820,7 +814,7 @@ udx_stream_init (udx_t *self, udx_stream_t *stream, uint32_t *local_id) {
   stream->stats_fast_rt = 0;
   stream->stats_last_seq = 0;
 
-  stream->on_read = NULL;
+  stream->on_data = NULL;
   stream->on_end = NULL;
   stream->on_drain = NULL;
   stream->on_ack = NULL;
@@ -836,35 +830,29 @@ udx_stream_init (udx_t *self, udx_stream_t *stream, uint32_t *local_id) {
   return 0;
 }
 
-int
-udx_stream_set_callback (udx_stream_t *self, enum UDX_CALLBACK name, void *fn) {
-  switch (name) {
-    case UDX_STREAM_ON_DATA: {
-      self->on_read = fn;
-      return 0;
-    }
-    case UDX_STREAM_ON_END: {
-      self->on_end = fn;
-      return 0;
-    }
-    case UDX_STREAM_ON_DRAIN: {
-      self->on_drain = fn;
-      return 0;
-    }
-    case UDX_STREAM_ON_ACK: {
-      self->on_ack = fn;
-      return 0;
-    }
-    case UDX_STREAM_ON_CLOSE: {
-      self->on_close = fn;
-      return 0;
-    }
-    default: {
-      return UV_EINVAL;
-    }
-  }
+void
+udx_stream_set_on_data(udx_stream_t *stream, udx_stream_data_cb cb) {
+  stream->on_data = cb;
+}
 
-  return UV_EINVAL;
+void
+udx_stream_set_on_end(udx_stream_t *stream, udx_stream_end_cb cb) {
+  stream->on_end = cb;
+}
+
+void
+udx_stream_set_on_drain(udx_stream_t *stream, udx_stream_drain_cb cb) {
+  stream->on_drain = cb;
+}
+
+void
+udx_stream_set_on_ack(udx_stream_t *stream, udx_stream_ack_cb cb) {
+  stream->on_ack = cb;
+}
+
+void
+udx_stream_set_on_close(udx_stream_t *stream, udx_stream_close_cb cb) {
+  stream->on_close = cb;
 }
 
 int


### PR DESCRIPTION
This serves two purposes:

1. Improve type safety, allowing compilers to emit warnings when function pointer types don't align.
2. Allow the use of C++ lambdas.