### PR TITLE
Store `pkt->type` in case `pkt` is freed in `on_send`

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -561,12 +561,14 @@ on_uv_poll (uv_poll_t *handle, int status, int events) {
       size = sendmsg(handle->io_watcher.fd, h, 0);
     } while (size == -1 && errno == EINTR);
 
-    if (pkt->type & UDX_PACKET_CALLBACK) {
+    int type = pkt->type;
+
+    if (type & UDX_PACKET_CALLBACK) {
       trigger_send_callback(self, pkt);
       // TODO: watch for re-entry here!
     }
 
-    if (pkt->type & UDX_PACKET_FREE_ON_SEND) {
+    if (type & UDX_PACKET_FREE_ON_SEND) {
       free(pkt);
     }
 


### PR DESCRIPTION
This caused a use after free and also risked a double free depending on whatever value `pkt->type` had after `pkt` was freed.