### PR TITLE
fix bug when a queued retransmit is acked before transmit

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -171,6 +171,7 @@ struct udx_packet {
   int status;
   int type;
   int ttl;
+  int is_retransmit;
 
   uint32_t fifo_gc;
 


### PR DESCRIPTION
If a packet was acked when queued for retransmit, then both pkts_waiting and retransmits_waiting would NOT get decremented, making the state machine stall.

This fixes that by explicitly marking if a packet is queued for retransmit or not.
I'd much prefer that to just have been a bit flag, but that requires some more refactoring, so will tweak that in a later PR.

Should fix the failing linux test in #57

To make an explicit test for this is a little tricky, but should be doable.

If we have a congestion hook or a way to disable SACKS then that should do the trick.