### PR TITLE
Test throwing in `data` callback

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -30,11 +30,19 @@
     napi_value fatal_exception; \
     napi_get_and_clear_last_exception(env, &fatal_exception); \
     napi_fatal_exception(env, fatal_exception); \
-    printf("oh no add that realloc\n"); \
+    { \
+      UDX_NAPI_CALLBACK(self, self->realloc, { \
+        NAPI_MAKE_CALLBACK(env, nil, ctx, callback, 0, NULL, &res); \
+        UDX_NAPI_SET_READ_BUFFER(self, res); \
+      }) \
+    } \
   } else { \
-    napi_get_buffer_info(env, ret, (void **) &(self->read_buf), &(self->read_buf_free)); \
-    self->read_buf_head = self->read_buf; \
+    UDX_NAPI_SET_READ_BUFFER(self, res); \
   }
+
+#define UDX_NAPI_SET_READ_BUFFER(self, res) \
+  napi_get_buffer_info(env, res, (void **) &(self->read_buf), &(self->read_buf_free)); \
+  self->read_buf_head = self->read_buf;
 
 typedef struct {
   udx_socket_t udx;
@@ -65,6 +73,7 @@ typedef struct {
   napi_ref on_send;
   napi_ref on_message;
   napi_ref on_close;
+  napi_ref realloc;
 } udx_napi_stream_t;
 
 inline static void
@@ -338,7 +347,7 @@ NAPI_METHOD(udx_napi_socket_close) {
 }
 
 NAPI_METHOD(udx_napi_stream_init) {
-  NAPI_ARGV(11)
+  NAPI_ARGV(12)
   NAPI_ARGV_BUFFER_CAST(udx_t *, udx, 0)
   NAPI_ARGV_BUFFER_CAST(udx_napi_stream_t *, stream, 1)
   NAPI_ARGV_UINT32(id, 2)
@@ -358,6 +367,7 @@ NAPI_METHOD(udx_napi_stream_init) {
   napi_create_reference(env, argv[8], 1, &(stream->on_send));
   napi_create_reference(env, argv[9], 1, &(stream->on_message));
   napi_create_reference(env, argv[10], 1, &(stream->on_close));
+  napi_create_reference(env, argv[11], 1, &(stream->realloc));
 
   int err = udx_stream_init(udx, (udx_stream_t *) stream, id);
   if (err < 0) UDX_NAPI_THROW(err)

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -38,7 +38,8 @@ module.exports = class UDXStream extends streamx.Duplex {
       this._onack,
       this._onsend,
       this._onmessage,
-      this._onclose
+      this._onclose,
+      this._realloc
     )
 
     binding.udx_napi_stream_recv_start(this._handle, this._readBuffer)
@@ -239,6 +240,11 @@ module.exports = class UDXStream extends streamx.Duplex {
 
     if (this._ondestroy === null) this.destroy(err)
     else this._destroyContinue(err)
+  }
+
+  _realloc () {
+    this._readBuffer = Buffer.allocUnsafe(BUFFER_SIZE)
+    return this._readBuffer
   }
 
   _allocWrite () {

--- a/test/stream.js
+++ b/test/stream.js
@@ -395,8 +395,9 @@ test('write string', async function (t) {
     .end('hello world')
 })
 
-test('throw in data callback', async function (t) {
-  t.plan(2)
+// Unskip once https://github.com/nodejs/node/issues/38155 is solved
+test.skip('throw in data callback', async function (t) {
+  t.plan(1)
 
   const u = new UDX()
 
@@ -415,12 +416,12 @@ test('throw in data callback', async function (t) {
 
   b.end(Buffer.from('hello'))
 
-  process.once('uncaughtException', (err) => {
+  process.once('uncaughtException', async (err) => {
     t.is(err.message, 'boom')
 
     a.destroy()
     b.destroy()
 
-    socket.close(() => t.pass('socket closed'))
+    await socket.close()
   })
 })


### PR DESCRIPTION
This currently fails on the native side:

```
node[1793]: ../src/api/callback.cc:141:void node::InternalCallbackScope::Close(): Assertion `(env_->execution_async_id()) == (0)' failed.
[162](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:162)
 1: 0xb09980 node::Abort() [node]
[163](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:163)
 2: 0xb099fe  [node]
[164](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:164)
 3: 0xa42ee0 node::InternalCallbackScope::Close() [node]
[165](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:165)
 4: 0xa432a5 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [node]
[166](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:166)
 5: 0xa43478 node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context) [node]
[167](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:167)
 6: 0xad1efb napi_make_callback [node]
[168](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:168)
 7: 0x7f62cca88f84  [/home/runner/work/libudx/libudx/build/Release/udx.node]
[169](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:169)
 8: 0x7f62cca8611c  [/home/runner/work/libudx/libudx/build/Release/udx.node]
[170](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:170)
 9: 0x7f62cca88830 udx_stream_destroy [/home/runner/work/libudx/libudx/build/Release/udx.node]
[171](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:171)
10: 0x7f62cca8ad92 udx_napi_stream_destroy [/home/runner/work/libudx/libudx/build/Release/udx.node]
[172](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:172)
11: 0xab44dd  [node]
[173](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:173)
12: 0xd53d8e  [node]
[174](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:174)
13: 0xd551af v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
[175](https://github.com/mafintosh/libudx/runs/6270239722?check_suite_focus=true#step:5:175)
14: 0x15f0bf9  [node]
```