### PR TITLE
Support writing strings to stream

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -1,5 +1,6 @@
 const util = require('util')
 const streamx = require('streamx')
+const b4a = require('b4a')
 const binding = require('./binding')
 
 const MAX_PACKET = 2048 // it's always way less than this, but whatevs
@@ -7,7 +8,7 @@ const BUFFER_SIZE = 65536 + MAX_PACKET
 
 module.exports = class UDXStream extends streamx.Duplex {
   constructor (udxHandle, id) {
-    super()
+    super({ mapWritable: toBuffer })
 
     this._socket = null
     this._udxHandle = udxHandle
@@ -255,3 +256,7 @@ module.exports = class UDXStream extends streamx.Duplex {
 }
 
 function noop () {}
+
+function toBuffer (data) {
+  return b4a.isBuffer(data) ? data : b4a.from(data)
+}

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -258,5 +258,5 @@ module.exports = class UDXStream extends streamx.Duplex {
 function noop () {}
 
 function toBuffer (data) {
-  return b4a.isBuffer(data) ? data : b4a.from(data)
+  return typeof data === 'string' ? b4a.from(data) : data
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/mafintosh/libudx#readme",
   "dependencies": {
+    "b4a": "^1.5.0",
     "napi-macros": "^2.0.0",
     "node-gyp-build": "^4.3.0",
     "streamx": "^2.12.0"

--- a/test/stream.js
+++ b/test/stream.js
@@ -359,9 +359,32 @@ test('close socket on stream close', async function (t) {
     })
 })
 
-test('write non-buffer', async function (t) {
-  const u = new UDX()
-  const stream = u.createStream(1)
+test('write string', async function (t) {
+  t.plan(3)
 
-  t.exception(() => stream.write('hello'))
+  const [a, b] = makeTwoStreams(t)
+
+  a
+    .on('data', function (data) {
+      t.alike(data, Buffer.from('hello world'))
+    })
+    .on('close', function () {
+      t.pass('a closed')
+    })
+    .end()
+
+  b
+    .on('close', function () {
+      t.pass('b closed')
+    })
+    .end('hello world')
+})
+
+test('write object', async function (t) {
+  const [a, b] = makeTwoStreams(t)
+
+  t.exception.all(() => a.write({ hello: 'world' }))
+
+  a.destroy()
+  b.destroy()
 })

--- a/test/stream.js
+++ b/test/stream.js
@@ -358,3 +358,10 @@ test('close socket on stream close', async function (t) {
       bSocket.close(() => t.pass('b closed'))
     })
 })
+
+test('write non-buffer', async function (t) {
+  const u = new UDX()
+  const stream = u.createStream(1)
+
+  t.exception(() => stream.write('hello'))
+})

--- a/test/stream.js
+++ b/test/stream.js
@@ -379,12 +379,3 @@ test('write string', async function (t) {
     })
     .end('hello world')
 })
-
-test('write object', async function (t) {
-  const [a, b] = makeTwoStreams(t)
-
-  t.exception.all(() => a.write({ hello: 'world' }))
-
-  a.destroy()
-  b.destroy()
-})


### PR DESCRIPTION
Currently fails on the native side:

```
node[1859]: ../src/node_buffer.cc:246:char* node::Buffer::Data(v8::Local<v8::Value>): Assertion `val->IsArrayBufferView()' failed.
[157](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:157)
 1: 0xb09980 node::Abort() [node]
[158](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:158)
 2: 0xb099fe  [node]
[159](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:159)
 3: 0xae06ca node::Buffer::Data(v8::Local<v8::Value>) [node]
[160](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:160)
 4: 0xad271e napi_get_buffer_info [node]
[161](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:161)
 5: 0x7fe6f8c95968 udx_napi_stream_write [/home/runner/work/libudx/libudx/build/Release/udx.node]
[162](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:162)
 6: 0xab44dd  [node]
[163](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:163)
 7: 0xd53d8e  [node]
[164](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:164)
 8: 0xd551af v8::internal::Builtin_HandleApiCall(int, unsigned long*, v8::internal::Isolate*) [node]
[165](https://github.com/mafintosh/libudx/runs/6270814260?check_suite_focus=true#step:5:165)
 9: 0x15f0bf9  [node]
```