### PR TITLE
Modernise JavaScript API and align with ecosystem

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -56,17 +56,14 @@ module.exports = class UDXSocket extends events.EventEmitter {
   _onsend (id, err) {
     const req = this._reqs[id]
 
-    const resolve = req.resolve
-    const reject = req.reject
+    const onflush = req.onflush
 
     req.buffer = null
-    req.resolve = null
-    req.reject = null
+    req.onflush = null
 
     this._free.push(id)
 
-    if (err < 0) reject(new Error('Send failed'))
-    else resolve()
+    onflush(err >= 0)
 
     // gc the free list
     if (this._free.length >= 16 && this._free.length === this._reqs.length) {
@@ -107,17 +104,10 @@ module.exports = class UDXSocket extends events.EventEmitter {
 
     if (!this._inited) this._init()
 
-    try {
-      this._port = binding.udx_napi_socket_bind(this._handle, port, host)
-      this._host = host
-    } catch (err) {
-      this.emit('error', err)
-      return
-    }
+    this._port = binding.udx_napi_socket_bind(this._handle, port, host)
+    this._host = host
 
-    queueMicrotask(() => {
-      if (this.bound) this.emit('listening')
-    })
+    this.emit('listening')
   }
 
   async close () {
@@ -159,11 +149,9 @@ module.exports = class UDXSocket extends events.EventEmitter {
   }
 
   async send (buffer, port, host, ttl) {
-    // TODO: should this be an error?
-    if (this.closing) throw new Error('Socket is closed')
+    if (this.closing) return false
 
     if (!host) host = '127.0.0.1'
-
     if (!this.bound) this.bind(0)
 
     const id = this._allocSend()
@@ -171,9 +159,8 @@ module.exports = class UDXSocket extends events.EventEmitter {
 
     req.buffer = buffer
 
-    const promise = new Promise((resolve, reject) => {
-      req.resolve = resolve
-      req.reject = reject
+    const promise = new Promise((resolve) => {
+      req.onflush = resolve
     })
 
     binding.udx_napi_socket_send_ttl(this._handle, req.handle, id, buffer, port, host, ttl || 0)
@@ -182,13 +169,24 @@ module.exports = class UDXSocket extends events.EventEmitter {
   }
 
   trySend (buffer, port, host, ttl) {
-    this.send(buffer, port, host, ttl).catch(noop)
+    if (this.closing) return
+
+    if (!host) host = '127.0.0.1'
+    if (!this.bound) this.bind(0)
+
+    const id = this._allocSend()
+    const req = this._reqs[id]
+
+    req.buffer = buffer
+    req.onflush = noop
+
+    binding.udx_napi_socket_send_ttl(this._handle, req.handle, id, buffer, port, host, ttl || 0)
   }
 
   _allocSend () {
     if (this._free.length > 0) return this._free.pop()
     const handle = b4a.allocUnsafe(binding.sizeof_udx_socket_send_t)
-    return this._reqs.push({ handle, buffer: null, resolve: null, reject: null }) - 1
+    return this._reqs.push({ handle, buffer: null, onflush: null }) - 1
   }
 }
 

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -181,12 +181,18 @@ module.exports = class UDXSocket extends events.EventEmitter {
     return promise
   }
 
+  trySend (buffer, port, host, ttl) {
+    this.send(buffer, port, host, ttl).catch(noop)
+  }
+
   _allocSend () {
     if (this._free.length > 0) return this._free.pop()
     const handle = b4a.allocUnsafe(binding.sizeof_udx_socket_send_t)
     return this._reqs.push({ handle, buffer: null, resolve: null, reject: null }) - 1
   }
 }
+
+function noop () {}
 
 function isIPv4 (host) {
   return IPv4Pattern.test(host)

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -1,5 +1,4 @@
 const binding = require('./binding')
-const UDXStream = require('./stream')
 const events = require('events')
 const b4a = require('b4a')
 
@@ -13,18 +12,25 @@ module.exports = class UDXSocket extends events.EventEmitter {
 
     this._handle = b4a.allocUnsafe(binding.sizeof_udx_napi_socket_t)
     this._inited = false
-    this._ip = null
+    this._host = null
     this._port = 0
     this._reqs = []
     this._free = []
+    this._closing = null
 
     this.streams = new Set()
-    this.bound = false
-    this.closing = false
   }
 
-  static isIPv4 (ip) {
-    return isIPv4(ip)
+  static isIPv4 (host) {
+    return isIPv4(host)
+  }
+
+  get bound () {
+    return this._port !== 0
+  }
+
+  get closing () {
+    return this._closing !== null
   }
 
   get idle () {
@@ -50,12 +56,17 @@ module.exports = class UDXSocket extends events.EventEmitter {
   _onsend (id, err) {
     const req = this._reqs[id]
 
-    const onflush = req.onflush
+    const resolve = req.resolve
+    const reject = req.reject
+
     req.buffer = null
-    req.onflush = null
+    req.resolve = null
+    req.reject = null
+
     this._free.push(id)
 
-    onflush(err < 0 ? new Error('Send failed') : null)
+    if (err < 0) reject(new Error('Send failed'))
+    else resolve()
 
     // gc the free list
     if (this._free.length >= 16 && this._free.length === this._reqs.length) {
@@ -64,8 +75,8 @@ module.exports = class UDXSocket extends events.EventEmitter {
     }
   }
 
-  _onmessage (buf, port, ip) {
-    this.emit('message', buf, { address: ip, family: 'IPv4', port })
+  _onmessage (buf, port, host) {
+    this.emit('message', buf, { host, family: 4, port })
   }
 
   _onclose () {
@@ -83,52 +94,43 @@ module.exports = class UDXSocket extends events.EventEmitter {
 
   address () {
     if (!this.bound) return null
-    return { address: this._ip, family: 'IPv4', port: this._port }
+    return { host: this._host, family: 4, port: this._port }
   }
 
-  bind (port, ip, onlistening) {
-    if (typeof port === 'function') return this.bind(0, null, onlistening)
-    if (typeof ip === 'function') return this.bind(port, null, ip)
+  bind (port, host) {
     if (this.bound) throw new Error('Already bound')
     if (this.closing) throw new Error('Socket is closed')
-    if (!port) port = 0
-    if (!ip) ip = '0.0.0.0'
-    if (!isIPv4(ip)) throw new Error('Can only bind to IPv4 currently')
 
-    if (onlistening) this.once('listening', onlistening)
+    if (!port) port = 0
+    if (!host) host = '0.0.0.0'
+    if (!isIPv4(host)) throw new Error('Can only bind to IPv4 currently')
 
     if (!this._inited) this._init()
 
     try {
-      this._port = binding.udx_napi_socket_bind(this._handle, port, ip)
-      this._ip = ip
+      this._port = binding.udx_napi_socket_bind(this._handle, port, host)
+      this._host = host
     } catch (err) {
       this.emit('error', err)
       return
     }
 
-    this.bound = true
-
-    // nextTicked here for nodejs compat
-    queueMicrotask(() => { if (this.bound) this.emit('listening') })
+    queueMicrotask(() => {
+      if (this.bound) this.emit('listening')
+    })
   }
 
-  close (onclose) {
-    if (this.closing) return
-    this.closing = true
-
-    if (onclose) this.once('close', onclose)
-
-    if (this.streams.size) return
-
-    if (this._inited) binding.udx_napi_socket_close(this._handle)
-    else queueMicrotask(() => this.emit('close'))
+  async close () {
+    if (this._closing) return this._closing
+    this._closing = new Promise((resolve) => this.once('close', resolve))
+    this._closeMaybe()
+    return this._closing
   }
 
   _closeMaybe () {
-    if (!this.closing || this.streams.size > 0) return
-    this.closing = false
-    this.close()
+    if (this._inited && this.closing && this.idle) {
+      binding.udx_napi_socket_close(this._handle)
+    }
   }
 
   setTTL (ttl) {
@@ -156,45 +158,36 @@ module.exports = class UDXSocket extends events.EventEmitter {
     return binding.udx_napi_socket_send_buffer_size(this._handle, size)
   }
 
-  send (buffer, offset, length, port, ip, ttl, onflush) {
-    if (typeof ttl === 'function') {
-      onflush = ttl
-      ttl = 0
-    }
+  async send (buffer, port, host, ttl) {
+    // TODO: should this be an error?
+    if (this.closing) throw new Error('Socket is closed')
 
-    if (this.closing) {
-      if (onflush) onflush(new Error('Socket is closed'))
-      return
-    }
+    if (!host) host = '127.0.0.1'
 
     if (!this.bound) this.bind(0)
 
     const id = this._allocSend()
     const req = this._reqs[id]
 
-    req.buffer = buffer.subarray(offset, offset + length)
-    req.onflush = onflush || noop
+    req.buffer = buffer
 
-    binding.udx_napi_socket_send_ttl(this._handle, req.handle, id, buffer, port, ip, ttl || 0)
+    const promise = new Promise((resolve, reject) => {
+      req.resolve = resolve
+      req.reject = reject
+    })
+
+    binding.udx_napi_socket_send_ttl(this._handle, req.handle, id, buffer, port, host, ttl || 0)
+
+    return promise
   }
 
   _allocSend () {
     if (this._free.length > 0) return this._free.pop()
     const handle = b4a.allocUnsafe(binding.sizeof_udx_socket_send_t)
-    return this._reqs.push({ handle, buffer: null, onflush: null }) - 1
-  }
-
-  static createSocket () {
-    return new this()
-  }
-
-  static createStream (id) {
-    return new UDXStream(id)
+    return this._reqs.push({ handle, buffer: null, resolve: null, reject: null }) - 1
   }
 }
 
-function noop () {}
-
-function isIPv4 (ip) {
-  return IPv4Pattern.test(ip)
+function isIPv4 (host) {
+  return IPv4Pattern.test(host)
 }

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -125,6 +125,10 @@ module.exports = class UDXStream extends streamx.Duplex {
     return promise
   }
 
+  trySend (buffer) {
+    this.send(buffer).catch(noop)
+  }
+
   _read (cb) {
     cb(null)
   }
@@ -277,6 +281,8 @@ module.exports = class UDXStream extends streamx.Duplex {
     return this._sreqs.push({ handle, buffer: null, resolve: null, reject: null }) - 1
   }
 }
+
+function noop () {}
 
 function toBuffer (data) {
   return typeof data === 'string' ? b4a.from(data) : data

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -28,8 +28,6 @@ module.exports = class UDXStream extends streamx.Duplex {
     this._ondestroy = null
     this._firewall = opts.firewall || firewallAll
 
-    this.connected = false
-
     this.id = id
     this.remoteId = 0
     this.remotePort = 0
@@ -49,6 +47,10 @@ module.exports = class UDXStream extends streamx.Duplex {
     binding.udx_napi_stream_recv_start(this._handle, this._readBuffer)
   }
 
+  get connected () {
+    return this.socket !== null
+  }
+
   get rtt () {
     return this._view[binding.offsetof_udx_stream_t_srtt >> 2]
   }
@@ -59,6 +61,14 @@ module.exports = class UDXStream extends streamx.Duplex {
 
   get inflight () {
     return this._view[binding.offsetof_udx_stream_t_inflight >> 2]
+  }
+
+  get localPort () {
+    return this.socket ? this.socket.address().port : null
+  }
+
+  get localHost () {
+    return this.socket ? this.socket.address().host : null
   }
 
   setInteractive (bool) {
@@ -79,8 +89,6 @@ module.exports = class UDXStream extends streamx.Duplex {
     this.remoteId = remoteId
     this.remotePort = port
     this.remoteHost = host
-    this.connected = true
-
     this.socket = socket
 
     binding.udx_napi_stream_connect(this._handle, socket._handle, remoteId, port, host)
@@ -96,19 +104,25 @@ module.exports = class UDXStream extends streamx.Duplex {
     })
   }
 
-  send (buffer, onflush) {
+  async send (buffer) {
     if (!this.connected) throw new Error('Socket not connected')
-    if (!onflush) onflush = noop
 
-    if (this.destroying) return onflush(new Error('Socket destroyed'))
+    // TODO: should this be an error?
+    if (this.destroying) throw new Error('Socket destroyed')
 
     const id = this._allocSend()
     const req = this._sreqs[id]
 
     req.buffer = buffer
-    req.onflush = onflush
+
+    const promise = new Promise((resolve, reject) => {
+      req.resolve = resolve
+      req.reject = reject
+    })
 
     binding.udx_napi_stream_send(this._handle, req.handle, id, buffer)
+
+    return promise
   }
 
   _read (cb) {
@@ -202,12 +216,17 @@ module.exports = class UDXStream extends streamx.Duplex {
   _onsend (id, err) {
     const req = this._sreqs[id]
 
-    const onflush = req.onflush
+    const resolve = req.resolve
+    const reject = req.reject
+
     req.buffer = null
-    req.onflush = null
+    req.resolve = null
+    req.reject = null
+
     this._sfree.push(id)
 
-    onflush(err < 0 ? new Error('Send failed') : null)
+    if (err < 0) reject(new Error('Send failed'))
+    else resolve()
 
     // gc the free list
     if (this._sfree.length >= 16 && this._sfree.length === this._sreqs.length) {
@@ -255,11 +274,9 @@ module.exports = class UDXStream extends streamx.Duplex {
   _allocSend () {
     if (this._sfree.length > 0) return this._sfree.pop()
     const handle = b4a.allocUnsafe(binding.sizeof_udx_stream_send_t)
-    return this._sreqs.push({ handle, buffer: null, onflush: null }) - 1
+    return this._sreqs.push({ handle, buffer: null, resolve: null, reject: null }) - 1
   }
 }
-
-function noop () {}
 
 function toBuffer (data) {
   return typeof data === 'string' ? b4a.from(data) : data

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -105,19 +105,15 @@ module.exports = class UDXStream extends streamx.Duplex {
   }
 
   async send (buffer) {
-    if (!this.connected) throw new Error('Socket not connected')
-
-    // TODO: should this be an error?
-    if (this.destroying) throw new Error('Socket destroyed')
+    if (!this.connected || this.destroying) return false
 
     const id = this._allocSend()
     const req = this._sreqs[id]
 
     req.buffer = buffer
 
-    const promise = new Promise((resolve, reject) => {
-      req.resolve = resolve
-      req.reject = reject
+    const promise = new Promise((resolve) => {
+      req.onflush = resolve
     })
 
     binding.udx_napi_stream_send(this._handle, req.handle, id, buffer)
@@ -126,7 +122,15 @@ module.exports = class UDXStream extends streamx.Duplex {
   }
 
   trySend (buffer) {
-    this.send(buffer).catch(noop)
+    if (!this.connected || this.destroying) return
+
+    const id = this._allocSend()
+    const req = this._sreqs[id]
+
+    req.buffer = buffer
+    req.onflush = noop
+
+    binding.udx_napi_stream_send(this._handle, req.handle, id, buffer)
   }
 
   _read (cb) {
@@ -220,17 +224,14 @@ module.exports = class UDXStream extends streamx.Duplex {
   _onsend (id, err) {
     const req = this._sreqs[id]
 
-    const resolve = req.resolve
-    const reject = req.reject
+    const onflush = req.onflush
 
     req.buffer = null
-    req.resolve = null
-    req.reject = null
+    req.onflush = null
 
     this._sfree.push(id)
 
-    if (err < 0) reject(new Error('Send failed'))
-    else resolve()
+    onflush(err >= 0)
 
     // gc the free list
     if (this._sfree.length >= 16 && this._sfree.length === this._sreqs.length) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -105,17 +105,11 @@ test('close socket while sending', async function (t) {
 
   a.bind()
 
-  t.exception(
-    a.send(Buffer.from('hello'), a.address().port),
-    /Send failed/
-  )
-
-  t.exception(
-    a.send(Buffer.from('world'), a.address().port),
-    /Send failed/
-  )
+  const flushed = a.send(Buffer.from('hello'), a.address().port)
 
   a.close()
+
+  t.is(await flushed, false)
 })
 
 test('close waits for all streams to close', async function (t) {
@@ -193,8 +187,5 @@ test('send after close', async function (t) {
   a.bind(0)
   a.close()
 
-  t.exception(
-    a.send(Buffer.from('hello'), a.address().port),
-    /Socket is closed/
-  )
+  t.is(await a.send(Buffer.from('hello'), a.address().port), false)
 })

--- a/test/socket.js
+++ b/test/socket.js
@@ -2,24 +2,16 @@ const test = require('brittle')
 const UDX = require('../')
 
 test('can bind and close', async function (t) {
-  t.plan(2)
-
   const u = new UDX()
   const s = u.createSocket()
 
-  s.bind(0, function () {
-    t.pass('socket is listening')
-    s.close()
-  })
+  s.bind(0)
+  await s.close()
 
-  s.on('close', function () {
-    t.pass('socket closed')
-  })
+  t.pass()
 })
 
 test('bind is effectively sync', async function (t) {
-  t.plan(4)
-
   const u = new UDX()
 
   const a = u.createSocket()
@@ -30,36 +22,31 @@ test('bind is effectively sync', async function (t) {
   t.ok(a.address().port, 'has bound')
   t.exception(() => b.bind(a.address().port))
 
-  a.close()
-  b.close()
-
-  a.on('close', () => t.pass('a closed'))
-  b.on('close', () => t.pass('b closed'))
+  await a.close()
+  await b.close()
 })
 
 test('simple message', async function (t) {
   t.plan(3)
 
   const u = new UDX()
-
   const a = u.createSocket()
 
-  a.on('message', function (message, { address, port }) {
+  a.on('message', function (message, { host, port }) {
     t.alike(message, Buffer.from('hello'))
-    t.is(address, '127.0.0.1')
+    t.is(host, '127.0.0.1')
     t.is(port, a.address().port)
     a.close()
   })
 
   a.bind(0)
-  a.send(Buffer.from('hello'), 0, 5, a.address().port, '127.0.0.1')
+  await a.send(Buffer.from('hello'), a.address().port)
 })
 
 test('empty message', async function (t) {
   t.plan(1)
 
   const u = new UDX()
-
   const a = u.createSocket()
 
   a.on('message', function (message) {
@@ -68,7 +55,7 @@ test('empty message', async function (t) {
   })
 
   a.bind(0)
-  a.send(Buffer.alloc(0), 0, 0, a.address().port, '127.0.0.1')
+  await a.send(Buffer.alloc(0), a.address().port)
 })
 
 test('echo sockets (250 messages)', async function (t) {
@@ -84,9 +71,9 @@ test('echo sockets (250 messages)', async function (t) {
   let echoed = 0
   let flushed = 0
 
-  a.on('message', function (buf, { address, port }) {
+  a.on('message', function (buf, { host, port }) {
     echoed++
-    a.send(buf, 0, buf.byteLength, port, address)
+    a.send(buf, port, host)
   })
 
   b.on('message', function (buf) {
@@ -106,28 +93,27 @@ test('echo sockets (250 messages)', async function (t) {
   while (send.length < 250) {
     const buf = Buffer.from('a message')
     send.push(buf)
-    b.send(buf, 0, buf.byteLength, a.address().port, '127.0.0.1', function () {
+    b.send(buf, a.address().port).then(function () {
       flushed++
     })
   }
 })
 
 test('close socket while sending', async function (t) {
-  t.plan(2)
-
   const u = new UDX()
-
   const a = u.createSocket()
 
   a.bind()
 
-  a.send(Buffer.from('hello'), 0, 5, a.address().port, '127.0.0.1', function (err) {
-    t.ok(err, 'send was not flushed')
-  })
+  t.exception(
+    a.send(Buffer.from('hello'), a.address().port),
+    /Send failed/
+  )
 
-  a.send(Buffer.from('world'), 0, 5, a.address().port, '127.0.0.1', function (err) {
-    t.ok(err, 'send was not flushed')
-  })
+  t.exception(
+    a.send(Buffer.from('world'), a.address().port),
+    /Send failed/
+  )
 
   a.close()
 })
@@ -171,17 +157,16 @@ test('open + close a bunch of sockets', async function (t) {
   l.plan(5)
   loop()
 
-  function loop () {
+  async function loop () {
     count++
 
     const a = u.createSocket()
 
     a.bind(0)
     l.pass('opened socket')
-    a.close(function () {
-      if (count === 5) return
-      loop()
-    })
+    await a.close()
+
+    if (count < 5) loop()
   }
 
   await l
@@ -192,7 +177,7 @@ test('open + close a bunch of sockets', async function (t) {
   for (let i = 0; i < 5; i++) {
     const a = u.createSocket()
     a.bind(0)
-    a.close(function () {
+    a.close().then(function () {
       p.pass('opened and closed socket')
     })
   }
@@ -201,8 +186,6 @@ test('open + close a bunch of sockets', async function (t) {
 })
 
 test('send after close', async function (t) {
-  t.plan(1)
-
   const u = new UDX()
 
   const a = u.createSocket()
@@ -210,7 +193,8 @@ test('send after close', async function (t) {
   a.bind(0)
   a.close()
 
-  a.send(Buffer.from('hello'), 0, 5, a.address().port, '127.0.0.1', function (err) {
-    t.ok(err)
-  })
+  t.exception(
+    a.send(Buffer.from('hello'), a.address().port),
+    /Socket is closed/
+  )
 })

--- a/test/stream.js
+++ b/test/stream.js
@@ -169,8 +169,6 @@ test('several streams on same socket', async function (t) {
   const socket = u.createSocket()
   socket.bind(0)
 
-  t.teardown(() => socket.close())
-
   for (let i = 0; i < 10; i++) {
     const stream = u.createStream(i)
     stream.connect(socket, i, socket.address().port)
@@ -178,6 +176,7 @@ test('several streams on same socket', async function (t) {
     t.teardown(() => stream.destroy())
   }
 
+  t.teardown(() => socket.close())
   t.pass('halts')
 })
 
@@ -262,11 +261,13 @@ test('destroy streams and close socket in callback', async function (t) {
   a.connect(socket, 2, socket.address().port)
   b.connect(socket, 1, socket.address().port)
 
-  a.on('data', function (data) {
+  a.on('data', async function (data) {
     a.destroy()
     b.destroy()
 
-    socket.close(() => t.pass('closed'))
+    await socket.close()
+
+    t.pass('closed')
   })
 
   b.write(Buffer.from('hello'))
@@ -357,8 +358,9 @@ test('close socket on stream close', async function (t) {
   b.connect(bSocket, 1, aSocket.address().port)
 
   a
-    .on('close', function () {
-      aSocket.close(() => t.pass('a closed'))
+    .on('close', async function () {
+      await aSocket.close()
+      t.pass('a closed')
     })
     .end()
 
@@ -366,8 +368,9 @@ test('close socket on stream close', async function (t) {
     .on('end', function () {
       b.end()
     })
-    .on('close', function () {
-      bSocket.close(() => t.pass('b closed'))
+    .on('close', async function () {
+      await bSocket.close()
+      t.pass('b closed')
     })
 })
 


### PR DESCRIPTION
Notable changes:

- Use promises where it makes sense.
- Consistently refer to IP addresses as `host`.
- Remove `offset` and `length` from `socket.send()`; just use `buffer.subarray()`.
- Add `stream.localPort` and `stream.localHost` as getters for `stream.socket.address()`.
- Add `socket.trySend()` and `stream.trySend()`.