### PR TITLE
update fast-recovery to resend the full missing segment

### DIFF
--- a/src/udx.c
+++ b/src/udx.c
@@ -693,7 +693,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     stream->dup_acks = 0;
   } else if ((type & UDX_HEADER_DATA_OR_END) == 0) {
     stream->dup_acks++;
-    if (stream->dup_acks >= 3) {
+    if (stream->dup_acks == 3) {
       fast_retransmit(stream);
     }
   }


### PR DESCRIPTION
This updates fast_retransmit (fast recovery) with a couple of things

1) It now retransmits the full range of packets that are missing instead of just one (reading up on fast recovery suggests this is ok, def works much better)
2) It skips retransmit if no range has been SACKED in front of it, as that suggests congestion otherwise. That also fixes a regression where an actual congestion event makes the algo think it should continuously retransmit.
3) Is less aggressive about lowering the transmission window (again per docs). Doesn't follow the spec fully yet, but this seems to work quite well in practice.
4) Resets the packet recovery timer whenever fast recovery runs