### PR TITLE
Add network interface events API

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -76,6 +76,15 @@ typedef struct {
   napi_ref realloc;
 } udx_napi_stream_t;
 
+typedef struct {
+  udx_interface_event_t handle;
+
+  napi_env env;
+  napi_ref ctx;
+  napi_ref on_event;
+  napi_ref on_close;
+} udx_napi_interface_event_t;
+
 inline static void
 parse_address (struct sockaddr *name, char *ip, int *port) {
   struct sockaddr_in *name_in = (struct sockaddr_in *) name;
@@ -244,11 +253,29 @@ on_udx_stream_firewall (udx_stream_t *stream, udx_socket_t *socket, const struct
   return fw;
 }
 
+static void
+on_udx_interface_event (udx_interface_event_t *handle, int status) {
+  udx_napi_interface_event_t *e = (udx_napi_interface_event_t *) handle;
+
+  UDX_NAPI_CALLBACK(e, e->on_event, {
+    NAPI_MAKE_CALLBACK(env, NULL, ctx, callback, 0, NULL, NULL)
+  })
+}
+
+static void
+on_udx_interface_event_close (udx_interface_event_t *handle) {
+  udx_napi_interface_event_t *e = (udx_napi_interface_event_t *) handle;
+
+  UDX_NAPI_CALLBACK(e, e->on_close, {
+    NAPI_MAKE_CALLBACK(env, NULL, ctx, callback, 0, NULL, NULL)
+  })
+}
+
 NAPI_METHOD(udx_napi_init) {
   NAPI_ARGV(1)
   NAPI_ARGV_BUFFER_CAST(udx_t *, self, 0)
 
-  struct uv_loop_s *loop;
+  uv_loop_t *loop;
   napi_get_uv_event_loop(env, &loop);
 
   udx_init(loop, self);
@@ -512,33 +539,84 @@ NAPI_METHOD(udx_napi_stream_destroy) {
   NAPI_RETURN_UINT32(err);
 }
 
-NAPI_METHOD(udx_napi_network_interfaces) {
-  uv_interface_address_t* interfaces;
-  int count, i = 0, j = 0;
-  char ip[17];
+NAPI_METHOD(udx_napi_interface_event_init) {
+  NAPI_ARGV(4)
+  NAPI_ARGV_BUFFER_CAST(udx_napi_interface_event_t *, self, 0)
 
-  int err = uv_interface_addresses(&interfaces, &count);
+  udx_interface_event_t *event = (udx_interface_event_t *) self;
+
+  uv_loop_t *loop;
+  napi_get_uv_event_loop(env, &loop);
+
+  self->env = env;
+  napi_create_reference(env, argv[1], 1, &(self->ctx));
+  napi_create_reference(env, argv[2], 1, &(self->on_event));
+  napi_create_reference(env, argv[3], 1, &(self->on_close));
+
+  int err = udx_interface_event_init(loop, event);
   if (err < 0) UDX_NAPI_THROW(err)
+
+  err = udx_interface_event_start(event, on_udx_interface_event, 5000);
+  if (err < 0) UDX_NAPI_THROW(err)
+
+  return NULL;
+}
+
+NAPI_METHOD(udx_napi_interface_event_start) {
+  NAPI_ARGV(1)
+  NAPI_ARGV_BUFFER_CAST(udx_interface_event_t *, event, 0)
+
+  int err = udx_interface_event_start(event, on_udx_interface_event, 5000);
+  if (err < 0) UDX_NAPI_THROW(err)
+
+  return NULL;
+}
+
+NAPI_METHOD(udx_napi_interface_event_stop) {
+  NAPI_ARGV(1)
+  NAPI_ARGV_BUFFER_CAST(udx_interface_event_t *, event, 0)
+
+  int err = udx_interface_event_stop(event);
+  if (err < 0) UDX_NAPI_THROW(err)
+
+  return NULL;
+}
+
+NAPI_METHOD(udx_napi_interface_event_close) {
+  NAPI_ARGV(1)
+  NAPI_ARGV_BUFFER_CAST(udx_interface_event_t *, event, 0)
+
+  int err = udx_interface_event_close(event, on_udx_interface_event_close);
+  if (err < 0) UDX_NAPI_THROW(err)
+
+  return NULL;
+}
+
+NAPI_METHOD(udx_napi_interface_event_get_addrs) {
+  NAPI_ARGV(1)
+  NAPI_ARGV_BUFFER_CAST(udx_interface_event_t *, event, 0)
+
+  char ip[17];
 
   napi_value result;
   napi_create_array(env, &result);
 
-  while (i < count) {
-    uv_interface_address_t network = interfaces[i++];
+  for (int i = 0, j = 0; i < event->addrs_len; i++) {
+    uv_interface_address_t addr = event->addrs[i];
 
     // We only care about IPv4 addresses for now.
-    if (network.address.address4.sin_family != AF_INET) {
+    if (addr.address.address4.sin_family != AF_INET) {
       continue;
     }
 
-    uv_ip4_name(&network.address.address4, ip, sizeof(ip));
+    uv_ip4_name(&addr.address.address4, ip, sizeof(ip));
 
     napi_value item;
     napi_create_object(env, &item);
     napi_set_element(env, result, j++, item);
 
     napi_value name;
-    napi_create_string_utf8(env, network.name, NAPI_AUTO_LENGTH, &name);
+    napi_create_string_utf8(env, addr.name, NAPI_AUTO_LENGTH, &name);
     napi_set_named_property(env, item, "name", name);
 
     napi_value host;
@@ -550,11 +628,9 @@ NAPI_METHOD(udx_napi_network_interfaces) {
     napi_set_named_property(env, item, "family", family);
 
     napi_value internal;
-    napi_get_boolean(env, network.is_internal, &internal);
+    napi_get_boolean(env, addr.is_internal, &internal);
     napi_set_named_property(env, item, "internal", internal);
   }
-
-  uv_free_interface_addresses(interfaces, count);
 
   return result;
 }
@@ -569,6 +645,7 @@ NAPI_INIT() {
   NAPI_EXPORT_SIZEOF(udx_t)
   NAPI_EXPORT_SIZEOF(udx_napi_socket_t)
   NAPI_EXPORT_SIZEOF(udx_napi_stream_t)
+  NAPI_EXPORT_SIZEOF(udx_napi_interface_event_t)
 
   NAPI_EXPORT_SIZEOF(udx_socket_send_t)
   NAPI_EXPORT_SIZEOF(udx_stream_write_t)
@@ -593,5 +670,9 @@ NAPI_INIT() {
   NAPI_EXPORT_FUNCTION(udx_napi_stream_write_end)
   NAPI_EXPORT_FUNCTION(udx_napi_stream_destroy)
 
-  NAPI_EXPORT_FUNCTION(udx_napi_network_interfaces)
+  NAPI_EXPORT_FUNCTION(udx_napi_interface_event_init)
+  NAPI_EXPORT_FUNCTION(udx_napi_interface_event_start)
+  NAPI_EXPORT_FUNCTION(udx_napi_interface_event_stop)
+  NAPI_EXPORT_FUNCTION(udx_napi_interface_event_close)
+  NAPI_EXPORT_FUNCTION(udx_napi_interface_event_get_addrs)
 }

--- a/binding.c
+++ b/binding.c
@@ -269,6 +269,10 @@ on_udx_interface_event_close (udx_interface_event_t *handle) {
   UDX_NAPI_CALLBACK(e, e->on_close, {
     NAPI_MAKE_CALLBACK(env, NULL, ctx, callback, 0, NULL, NULL)
   })
+
+  napi_delete_reference(env, e->ctx);
+  napi_delete_reference(env, e->on_event);
+  napi_delete_reference(env, e->on_close);
 }
 
 NAPI_METHOD(udx_napi_init) {

--- a/include/udx.h
+++ b/include/udx.h
@@ -51,6 +51,9 @@ extern "C" {
 #define UDX_HEADER_MESSAGE 0b01000
 #define UDX_HEADER_DESTROY 0b10000
 
+#define UDX_INTERFACE_ADD    0b01
+#define UDX_INTERFACE_REMOVE 0b10
+
 typedef struct {
   uint32_t seq;
 } udx_cirbuf_val_t;
@@ -79,6 +82,8 @@ typedef struct udx_socket_send udx_socket_send_t;
 typedef struct udx_stream_write udx_stream_write_t;
 typedef struct udx_stream_send udx_stream_send_t;
 
+typedef struct udx_interface_event udx_interface_event_t;
+
 typedef void (*udx_socket_send_cb)(udx_socket_send_t *req, int status);
 typedef void (*udx_socket_recv_cb)(udx_socket_t *handle, ssize_t read_len, const uv_buf_t *buf, const struct sockaddr *from);
 typedef void (*udx_socket_close_cb)(udx_socket_t *handle);
@@ -90,6 +95,9 @@ typedef void (*udx_stream_ack_cb)(udx_stream_write_t *req, int status, int unord
 typedef void (*udx_stream_send_cb)(udx_stream_send_t *req, int status);
 typedef void (*udx_stream_recv_cb)(udx_stream_t *handle, ssize_t read_len, const uv_buf_t *buf);
 typedef void (*udx_stream_close_cb)(udx_stream_t *handle, int status);
+
+typedef void (*udx_interface_event_cb)(udx_interface_event_t *handle, uv_interface_address_t *addr, int events, int status);
+typedef void (*udx_interface_event_close_cb)(udx_interface_event_t *handle);
 
 struct udx {
   uv_timer_t timer;
@@ -229,6 +237,19 @@ struct udx_stream_send {
   void *data;
 };
 
+struct udx_interface_event {
+  uv_timer_t timer;
+  uv_loop_t *loop;
+
+  uv_interface_address_t *addrs;
+  int addrs_len;
+
+  udx_interface_event_cb on_event;
+  udx_interface_event_close_cb on_close;
+
+  void *data;
+};
+
 int
 udx_init (uv_loop_t *loop, udx_t *handle);
 
@@ -308,6 +329,18 @@ udx_stream_write_end (udx_stream_write_t *req, udx_stream_t *handle, const uv_bu
 
 int
 udx_stream_destroy (udx_stream_t *handle);
+
+int
+udx_interface_event_init (uv_loop_t *loop, udx_interface_event_t *handle);
+
+int
+udx_interface_event_start (udx_interface_event_t *handle, udx_interface_event_cb cb, uint64_t frequency);
+
+int
+udx_interface_event_stop (udx_interface_event_t *handle);
+
+int
+udx_interface_event_close (udx_interface_event_t *handle, udx_interface_event_close_cb cb);
 
 #ifdef __cplusplus
 }

--- a/include/udx.h
+++ b/include/udx.h
@@ -51,9 +51,6 @@ extern "C" {
 #define UDX_HEADER_MESSAGE 0b01000
 #define UDX_HEADER_DESTROY 0b10000
 
-#define UDX_INTERFACE_ADD    0b01
-#define UDX_INTERFACE_REMOVE 0b10
-
 typedef struct {
   uint32_t seq;
 } udx_cirbuf_val_t;
@@ -96,7 +93,7 @@ typedef void (*udx_stream_send_cb)(udx_stream_send_t *req, int status);
 typedef void (*udx_stream_recv_cb)(udx_stream_t *handle, ssize_t read_len, const uv_buf_t *buf);
 typedef void (*udx_stream_close_cb)(udx_stream_t *handle, int status);
 
-typedef void (*udx_interface_event_cb)(udx_interface_event_t *handle, uv_interface_address_t *addr, int events, int status);
+typedef void (*udx_interface_event_cb)(udx_interface_event_t *handle, int status);
 typedef void (*udx_interface_event_close_cb)(udx_interface_event_t *handle);
 
 struct udx {

--- a/include/udx.h
+++ b/include/udx.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <uv.h>
 
 // TODO: research the packets sizes a bit more
@@ -240,6 +241,7 @@ struct udx_interface_event {
 
   uv_interface_address_t *addrs;
   int addrs_len;
+  bool sorted;
 
   udx_interface_event_cb on_event;
   udx_interface_event_close_cb on_close;

--- a/lib/network-interfaces.js
+++ b/lib/network-interfaces.js
@@ -1,0 +1,57 @@
+const events = require('events')
+const b4a = require('b4a')
+const binding = require('./binding')
+
+module.exports = class NetworkInterfaces extends events.EventEmitter {
+  constructor () {
+    super()
+
+    this._handle = b4a.allocUnsafe(binding.sizeof_udx_napi_interface_event_t)
+    this._watching = false
+    this._destroying = null
+
+    binding.udx_napi_interface_event_init(this._handle, this,
+      this._onevent,
+      this._onclose
+    )
+
+    this.interfaces = binding.udx_napi_interface_event_get_addrs(this._handle)
+  }
+
+  _onclose () {
+    this.emit('close')
+  }
+
+  _onevent () {
+    this.interfaces = binding.udx_napi_interface_event_get_addrs(this._handle)
+
+    this.emit('change', this.interfaces)
+  }
+
+  watch () {
+    if (this._watching) return this
+    this._watching = true
+
+    binding.udx_napi_interface_event_start(this._handle)
+
+    return this
+  }
+
+  unwatch () {
+    if (!this._watching) return this
+    this._watching = false
+
+    binding.udx_napi_interface_event_stop(this._handle)
+
+    return this
+  }
+
+  async destroy () {
+    if (this._destroying) return this._destroying
+    this._destroying = events.once(this, 'close')
+
+    binding.udx_napi_interface_event_close(this._handle)
+
+    return this._destroying
+  }
+}

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -112,7 +112,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
 
   async close () {
     if (this._closing) return this._closing
-    this._closing = new Promise((resolve) => this.once('close', resolve))
+    this._closing = events.once(this, 'close')
     this._closeMaybe()
     return this._closing
   }

--- a/lib/udx.js
+++ b/lib/udx.js
@@ -1,11 +1,14 @@
+const b4a = require('b4a')
 const binding = require('./binding')
 const Socket = require('./socket')
 const Stream = require('./stream')
-const b4a = require('b4a')
+const NetworkInterfaces = require('./network-interfaces')
 
 module.exports = class UDX {
   constructor () {
     this._handle = b4a.allocUnsafe(binding.sizeof_udx_t)
+    this._watchers = new Set()
+
     binding.udx_napi_init(this._handle)
   }
 
@@ -18,6 +21,25 @@ module.exports = class UDX {
   }
 
   networkInterfaces () {
-    return binding.udx_napi_network_interfaces()
+    let [watcher = null] = this._watchers
+    if (watcher) return watcher.interfaces
+
+    watcher = new NetworkInterfaces()
+    watcher.destroy()
+
+    return watcher.interfaces
+  }
+
+  watchNetworkInterfaces (onchange) {
+    const watcher = new NetworkInterfaces()
+
+    this._watchers.add(watcher)
+    watcher.on('close', () => {
+      this._watchers.delete(watcher)
+    })
+
+    if (onchange) watcher.on('change', onchange)
+
+    return watcher.watch()
   }
 }

--- a/src/udx.c
+++ b/src/udx.c
@@ -1474,8 +1474,6 @@ on_interface_event_close (uv_handle_t *handle) {
   if (event->on_close != NULL) {
     event->on_close(event);
   }
-
-  uv_free_interface_addresses(event->addrs, event->addrs_len);
 }
 
 int
@@ -1515,6 +1513,8 @@ int
 udx_interface_event_close (udx_interface_event_t *handle, udx_interface_event_close_cb cb) {
   handle->on_event = NULL;
   handle->on_close = cb;
+
+  uv_free_interface_addresses(event->addrs, event->addrs_len);
 
   int err = uv_timer_stop(&(handle->timer));
   if (err < 0) return err;

--- a/src/udx.c
+++ b/src/udx.c
@@ -1462,9 +1462,7 @@ on_interface_event_interval (uv_timer_t *timer) {
     }
   }
 
-  if (prev_addrs != NULL) {
-    uv_free_interface_addresses(prev_addrs, prev_addrs_len);
-  }
+  uv_free_interface_addresses(prev_addrs, prev_addrs_len);
 }
 
 static void

--- a/src/udx.c
+++ b/src/udx.c
@@ -1402,9 +1402,6 @@ cmp_interface (const void *a, const void *b) {
   result = memcmp(&ia->address, &ib->address, sizeof(ia->address));
   if (result != 0) return result;
 
-  result = memcmp(&ia->netmask, &ib->netmask, sizeof(ia->netmask));
-  if (result != 0) return result;
-
   return 0;
 }
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -1423,7 +1423,7 @@ on_interface_event_interval (uv_timer_t *timer) {
 
   qsort(handle->addrs, handle->addrs_len, sizeof(uv_interface_address_t), cmp_interface);
 
-  if (prev_addrs_len != handle->addrs_len) {
+  if (handle->addrs_len != prev_addrs_len) {
     handle->on_event(handle, 0);
   } else {
     for (int i = 0; i < handle->addrs_len; i++) {

--- a/src/udx.c
+++ b/src/udx.c
@@ -1512,12 +1512,12 @@ udx_interface_event_close (udx_interface_event_t *handle, udx_interface_event_cl
   handle->on_event = NULL;
   handle->on_close = cb;
 
-  uv_free_interface_addresses(event->addrs, event->addrs_len);
+  uv_free_interface_addresses(handle->addrs, handle->addrs_len);
 
   int err = uv_timer_stop(&(handle->timer));
   if (err < 0) return err;
 
-  uv_close((uv_handle_t *) &(handle->timer), NULL);
+  uv_close((uv_handle_t *) &(handle->timer), on_interface_event_close);
 
   return 0;
 }


### PR DESCRIPTION
On the JavaScript side, this PR adds a new `udx.watchNetworkInterfaces()` API:

```js
const watcher = udx.watchNetworkInterfaces((interfaces) => {
  console.log(interfaces)
})

watcher.destroy()
```